### PR TITLE
Adding type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - pip install .
   - pip install .[testing]
 
-script: pytest -x .
+script: pytest -x --mypy-ignore-missing-imports .

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Use the `data` argument to pass whatever extra context you want to be available
 in the templates. The arguments can be any valid Python value, even a
 function.
 
+Since X.X.X, only Python 3.6 or later are supported. Please use the 2.5.1 version if your project runs
+on a previous Python version.
 
 ## The copier.yml file
 

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import argparse
+import sys
 from hashlib import sha512
 from os import urandom
-import sys
 
 try:
     from .main import copy

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -72,7 +72,7 @@ parser.add_argument(
 )
 
 
-def run():  # pragma:no cover
+def run() -> None:  # pragma:no cover
     if len(sys.argv) == 1 or sys.argv[1] == "help":
         parser.print_help(sys.stderr)
         print()

--- a/copier/main.py
+++ b/copier/main.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Sequence, Tuple, Optional, Union
+from typing import Any, Dict, Sequence, Tuple, Optional, Union, Callable, List
 
 from . import vcs
 from .tools import (
@@ -28,6 +28,9 @@ __all__ = ("copy", "copy_local")
 StrOrPath = Union[str, Path]
 OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
 OptSeqStr = Optional[Sequence[str]]
+AnyByStr = Dict[str, Any]
+IntOrStr = Union[int, str]
+CheckPathFunc = Callable[[StrOrPath], bool]
 
 # Files of the template to exclude from the final project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (
@@ -59,7 +62,7 @@ def copy(
     include: OptSeqStr = None,
     skip_if_exists: OptSeqStr = None,
     tasks: OptSeqStr = None,
-    envops: Dict[str, Any] = None,
+    envops: AnyByStr = None,
     extra_paths: OptSeqStr = None,
     pretend: bool = False,
     force: bool = False,
@@ -193,19 +196,19 @@ def resolve_paths(
 def copy_local(
     src_path: StrOrPath,
     dst_path: StrOrPath,
-    data: Dict[str, Any],
+    data: AnyByStr,
     *,
     extra_paths: OptSeqStrOrPath = None,
     exclude: OptSeqStrOrPath = None,
     include: OptSeqStrOrPath = None,
     skip_if_exists: OptSeqStrOrPath = None,
     tasks: OptSeqStr = None,
-    envops: Dict[str, Any] = None,
+    envops: Optional[AnyByStr] = None,
     **flags: bool
 ) -> None:
     src_path, dst_path, extra_paths = resolve_paths(src_path, dst_path, extra_paths)
     config_data = load_config_data(src_path, quiet=flags["quiet"])
-    user_exclude = config_data.pop("_exclude", None)
+    user_exclude: List[str] = config_data.pop("_exclude", None)
     if exclude is None:
         exclude = user_exclude or DEFAULT_EXCLUDE
 
@@ -368,7 +371,7 @@ def overwrite_file(
     flags: Dict[str, bool],
 ) -> bool:
     if not flags["quiet"]:
-        printf("conflict", display_path, style=STYLE_DANGER)
+        printf("conflict", str(display_path), style=STYLE_DANGER)
     if flags["force"]:
         return True
     if flags["skip"]:

--- a/copier/main.py
+++ b/copier/main.py
@@ -11,7 +11,8 @@ from . import vcs
 from .tools import (STYLE_DANGER, STYLE_IGNORE, STYLE_OK, STYLE_WARNING,
                     Renderer, copy_file, get_jinja_renderer, get_name_filters,
                     make_folder, printf, prompt_bool)
-from .types import AnyByStrDict, OptStrOrPathSeq, OptStrSeq, StrOrPath
+from .types import (AnyByStrDict, CheckPathFunc, OptStrOrPathSeq, OptStrSeq,
+                    StrOrPath)
 from .user_data import load_config_data, query_user_data
 
 __all__ = ("copy", "copy_local")
@@ -296,7 +297,7 @@ def render_file(
     rel_path: Path,
     source_path: Path,
     engine: Renderer,
-    must_skip: Callable[[Path], bool],
+    must_skip: CheckPathFunc,
     flags: Dict[str, bool],
 ) -> None:
     """Process or copy a file of the skeleton.

--- a/copier/main.py
+++ b/copier/main.py
@@ -5,7 +5,9 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Sequence, Tuple, Optional, Union, Callable, List
+from typing import Dict, Tuple, Optional, List
+
+from .types import StrOrPath, OptSeqStrOrPath, OptSeqStr, AnyByStr
 
 from . import vcs
 from .tools import (
@@ -24,13 +26,6 @@ from .user_data import load_config_data, query_user_data
 
 __all__ = ("copy", "copy_local")
 
-# Custom Types
-StrOrPath = Union[str, Path]
-OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
-OptSeqStr = Optional[Sequence[str]]
-AnyByStr = Dict[str, Any]
-IntOrStr = Union[int, str]
-CheckPathFunc = Callable[[StrOrPath], bool]
 
 # Files of the template to exclude from the final project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (
@@ -50,13 +45,13 @@ DEFAULT_EXCLUDE: Tuple[str, ...] = (
 )
 
 DEFAULT_INCLUDE: Tuple[str, ...] = ()
-DEFAULT_DATA: Dict[str, Any] = {"now": datetime.datetime.utcnow}
+DEFAULT_DATA: AnyByStr = {"now": datetime.datetime.utcnow}
 
 
 def copy(
     src_path: str,
     dst_path: str,
-    data: Dict[str, Any] = None,
+    data: AnyByStr = None,
     *,
     exclude: OptSeqStr = None,
     include: OptSeqStr = None,

--- a/copier/main.py
+++ b/copier/main.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Callable
 
 from . import vcs
 from .tools import (
@@ -21,7 +21,7 @@ from .tools import (
     printf,
     prompt_bool,
 )
-from .types import AnyByStr, Callable, OptSeqStr, OptSeqStrOrPath, StrOrPath
+from .types import AnyByStrDict, OptStrSeq, OptStrOrPathSeq, StrOrPath
 from .user_data import load_config_data, query_user_data
 
 __all__ = ("copy", "copy_local")
@@ -45,20 +45,20 @@ DEFAULT_EXCLUDE: Tuple[str, ...] = (
 )
 
 DEFAULT_INCLUDE: Tuple[str, ...] = ()
-DEFAULT_DATA: AnyByStr = {"now": datetime.datetime.utcnow}
+DEFAULT_DATA: AnyByStrDict = {"now": datetime.datetime.utcnow}
 
 
 def copy(
     src_path: str,
     dst_path: str,
-    data: AnyByStr = None,
+    data: AnyByStrDict = None,
     *,
-    exclude: OptSeqStr = None,
-    include: OptSeqStr = None,
-    skip_if_exists: OptSeqStr = None,
-    tasks: OptSeqStr = None,
-    envops: AnyByStr = None,
-    extra_paths: OptSeqStr = None,
+    exclude: OptStrSeq = None,
+    include: OptStrSeq = None,
+    skip_if_exists: OptStrSeq = None,
+    tasks: OptStrSeq = None,
+    envops: AnyByStrDict = None,
+    extra_paths: OptStrSeq = None,
     pretend: bool = False,
     force: bool = False,
     skip: bool = False,
@@ -180,8 +180,8 @@ def resolve_source_path(path: StrOrPath) -> Path:
 
 
 def resolve_paths(
-    src_path: StrOrPath, dst_path: StrOrPath, extra_paths: OptSeqStrOrPath
-) -> Tuple[Path, Path, OptSeqStrOrPath]:
+    src_path: StrOrPath, dst_path: StrOrPath, extra_paths: OptStrOrPathSeq
+) -> Tuple[Path, Path, OptStrOrPathSeq]:
     src_path = resolve_source_path(src_path)
     dst_path = Path(dst_path).resolve()
     extra_paths = [str(resolve_source_path(p)) for p in extra_paths or []]
@@ -191,14 +191,14 @@ def resolve_paths(
 def copy_local(
     src_path: StrOrPath,
     dst_path: StrOrPath,
-    data: AnyByStr,
+    data: AnyByStrDict,
     *,
-    extra_paths: OptSeqStrOrPath = None,
-    exclude: OptSeqStrOrPath = None,
-    include: OptSeqStrOrPath = None,
-    skip_if_exists: OptSeqStrOrPath = None,
-    tasks: OptSeqStr = None,
-    envops: Optional[AnyByStr] = None,
+    extra_paths: OptStrOrPathSeq = None,
+    exclude: OptStrOrPathSeq = None,
+    include: OptStrOrPathSeq = None,
+    skip_if_exists: OptStrOrPathSeq = None,
+    tasks: OptStrSeq = None,
+    envops: Optional[AnyByStrDict] = None,
     **flags: bool
 ) -> None:
     src_path, dst_path, extra_paths = resolve_paths(src_path, dst_path, extra_paths)

--- a/copier/main.py
+++ b/copier/main.py
@@ -262,11 +262,17 @@ def copy_local(
             print("")  # padding space
 
 
-def get_source_paths(folder, rel_folder, files, render, must_filter):
+def get_source_paths(
+    folder: Path,
+    rel_folder: Path,
+    files: List[str],
+    engine: Renderer,
+    must_filter: Callable[[StrOrPath], bool],
+) -> List[Tuple[Path, Path]]:
     source_paths = []
     for src_name in files:
-        dst_name = re.sub(RE_TMPL, "", src_name)
-        dst_name = render.string(dst_name)
+        dst_name = re.sub(RE_TMPL, "", str(src_name))
+        dst_name = engine.string(dst_name)
         rel_path = rel_folder / dst_name
 
         if must_filter(rel_path):
@@ -305,6 +311,7 @@ def render_file(
 ) -> None:
     """Process or copy a file of the skeleton.
     """
+    content: Optional[str]
     if source_path.suffix == ".tmpl":
         content = engine(source_path)
     else:
@@ -363,7 +370,7 @@ def file_has_this_content(path: Path, content: str) -> bool:
 
 def overwrite_file(
     display_path: StrOrPath, source_path: Path, final_path: Path, flags: Dict[str, bool]
-) -> bool:
+) -> Optional[bool]:
     if not flags["quiet"]:
         printf("conflict", str(display_path), style=STYLE_DANGER)
     if flags["force"]:
@@ -375,10 +382,10 @@ def overwrite_file(
     return prompt_bool(msg, default=True)  # pragma:no cover
 
 
-def run_tasks(dst_path: StrOrPath, render, tasks) -> None:
+def run_tasks(dst_path: StrOrPath, engine: Renderer, tasks) -> None:
     dst_path = str(dst_path)
     for i, task in enumerate(tasks):
-        task = render.string(task)
+        task = engine.string(task)
         printf(
             " > Running task {} of {}".format(i + 1, len(tasks)), task, style=STYLE_OK
         )

--- a/copier/main.py
+++ b/copier/main.py
@@ -234,21 +234,22 @@ def copy_local(
     if not flags["quiet"]:
         print("")  # padding space
 
-    for _folder, _, files in os.walk(str(src_path)):
-        _rel_folder = _folder.replace(str(src_path), "", 1).lstrip(os.path.sep)
-        _rel_folder = engine.string(_rel_folder)
-        _rel_folder = _rel_folder.replace("." + os.path.sep, ".", 1)
+    folder: StrOrPath
+    rel_folder: StrOrPath
+    for folder, _, files in os.walk(str(src_path)):
+        rel_folder = str(folder).replace(str(src_path), "", 1).lstrip(os.path.sep)
+        rel_folder = engine.string(rel_folder)
+        rel_folder = str(rel_folder).replace("." + os.path.sep, ".", 1)
 
-        if must_filter(_rel_folder):
+        if must_filter(rel_folder):
             continue
 
-        folder: Path = Path(_folder)
-        rel_folder: Path = Path(_rel_folder)
+        folder = Path(folder)
+        rel_folder = Path(rel_folder)
 
         render_folder(dst_path, rel_folder, flags)
 
         source_paths = get_source_paths(folder, rel_folder, files, engine, must_filter)
-
         for source_path, rel_path in source_paths:
             render_file(dst_path, rel_path, source_path, engine, must_skip, flags)
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -5,23 +5,13 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Callable
+from typing import Callable, Dict, List, Optional, Tuple
 
 from . import vcs
-from .tools import (
-    STYLE_DANGER,
-    STYLE_IGNORE,
-    STYLE_OK,
-    STYLE_WARNING,
-    Renderer,
-    copy_file,
-    get_jinja_renderer,
-    get_name_filters,
-    make_folder,
-    printf,
-    prompt_bool,
-)
-from .types import AnyByStrDict, OptStrSeq, OptStrOrPathSeq, StrOrPath
+from .tools import (STYLE_DANGER, STYLE_IGNORE, STYLE_OK, STYLE_WARNING,
+                    Renderer, copy_file, get_jinja_renderer, get_name_filters,
+                    make_folder, printf, prompt_bool)
+from .types import AnyByStrDict, OptStrOrPathSeq, OptStrSeq, StrOrPath
 from .user_data import load_config_data, query_user_data
 
 __all__ = ("copy", "copy_local")

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -14,7 +14,6 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from .types import AnyByStrDict, OptStrOrPathSeq, StrOrPath, T
 
-
 _all__: Tuple[str, ...] = (
     "STYLE_OK",
     "STYLE_WARNING",

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -12,7 +12,7 @@ from colorama import Fore, Style
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 
-from .types import AnyByStrDict, OptStrOrPathSeq, StrOrPath, T
+from .types import AnyByStrDict, CheckPathFunc, OptStrOrPathSeq, StrOrPath, T
 
 _all__: Tuple[str, ...] = (
     "STYLE_OK",
@@ -51,7 +51,7 @@ def printf_block(
     style: List[int] = STYLE_WARNING,
     indent: int = 0,
     quiet: bool = False,
-):
+) -> None:
     if not quiet:
         print("")
         printf(action, msg=msg, style=style, indent=indent)
@@ -222,7 +222,7 @@ def get_name_filters(
     exclude: Sequence[StrOrPath],
     include: Sequence[StrOrPath],
     skip_if_exists: Sequence[StrOrPath],
-) -> Tuple[Callable[[StrOrPath], bool], Callable[[StrOrPath], bool]]:
+) -> Tuple[CheckPathFunc, CheckPathFunc]:
     """Returns a function that evaluates if aCheckPathFunc file or folder name must be
     filtered out, and another that evaluates if a file must be skipped.
 

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -12,7 +12,8 @@ from colorama import Fore, Style
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 
-from .types import AnyByStr, CheckPathFunc, OptSeqStrOrPath, StrOrPath
+from .types import AnyByStrDict, OptStrOrPathSeq, StrOrPath, T
+
 
 _all__: Tuple[str, ...] = (
     "STYLE_OK",
@@ -63,7 +64,8 @@ def printf_block(
 no_value = object()
 
 
-def required(value: Any, **kwargs: Any) -> Any:
+
+def required(value: T, **kwargs: Any) -> T:
     if not value:
         raise ValueError()
     return value
@@ -74,7 +76,7 @@ def prompt(
     default: Optional[Any] = no_value,
     default_show: Optional[Any] = None,
     validator: Callable = required,
-    **kwargs: AnyByStr
+    **kwargs: AnyByStrDict
 ) -> Optional[Any]:
     """
     Prompt for a value from the command line. A default value can be provided,
@@ -161,7 +163,7 @@ def copy_file(src: Path, dst: Path, symlinks: bool = True) -> None:
 
 
 # The default env options for jinja2
-DEFAULT_ENV_OPTIONS: AnyByStr = {
+DEFAULT_ENV_OPTIONS: AnyByStrDict = {
     "autoescape": False,
     "block_start_string": "[%",
     "block_end_string": "%]",
@@ -173,7 +175,7 @@ DEFAULT_ENV_OPTIONS: AnyByStr = {
 
 class Renderer:
     def __init__(
-        self, env: SandboxedEnvironment, src_path: str, data: AnyByStr
+        self, env: SandboxedEnvironment, src_path: str, data: AnyByStrDict
     ) -> None:
         self.env = env
         self.src_path = src_path
@@ -191,9 +193,9 @@ class Renderer:
 
 def get_jinja_renderer(
     src_path: Path,
-    data: AnyByStr,
-    extra_paths: OptSeqStrOrPath = None,
-    envops: Optional[AnyByStr] = None,
+    data: AnyByStrDict,
+    extra_paths: OptStrOrPathSeq = None,
+    envops: Optional[AnyByStrDict] = None,
 ) -> Renderer:
     """Returns a function that can render a Jinja template.
     """
@@ -222,7 +224,7 @@ def get_name_filters(
     exclude: Sequence[StrOrPath],
     include: Sequence[StrOrPath],
     skip_if_exists: Sequence[StrOrPath],
-) -> Tuple[CheckPathFunc, CheckPathFunc]:
+) -> Tuple[Callable[[StrOrPath], bool], Callable[[StrOrPath], bool]]:
     """Returns a function that evaluates if aCheckPathFunc file or folder name must be
     filtered out, and another that evaluates if a file must be skipped.
 

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -5,20 +5,14 @@ import unicodedata
 from fnmatch import fnmatch
 from functools import reduce
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, Callable, Iterable
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import colorama  # type: ignore
 import jinja2
 from colorama import Fore, Style
 from jinja2.sandbox import SandboxedEnvironment
 
-# Custom Types
-StrOrPath = Union[str, Path]
-OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
-OptSeqStr = Optional[Sequence[str]]
-AnyByStr = Dict[str, Any]
-IntOrStr = Union[int, str]
-CheckPathFunc = Callable[[StrOrPath], bool]
+from .types import OptSeqStrOrPath, AnyByStr, CheckPathFunc
 
 
 _all__: Tuple[str, ...] = (

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -33,7 +33,7 @@ STYLE_DANGER: List[int] = [Fore.RED, Style.BRIGHT]
 
 
 def printf(
-    action: str, msg: str = "", style: List[int] = None, indent: int = 10
+    action: str, msg: str = "", style: Optional[List[int]] = None, indent: int = 10
 ) -> Optional[str]:
     action = action.rjust(indent, " ")
     if not style:
@@ -45,7 +45,7 @@ def printf(
 
 
 def printf_block(
-    e,
+    e: Exception,
     action: str,
     msg: str = "",
     style: List[int] = STYLE_WARNING,
@@ -60,7 +60,7 @@ def printf_block(
         print("-" * 42)
 
 
-no_value = object()
+no_value: object = object()
 
 
 def required(value: T, **kwargs: Any) -> T:

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -64,7 +64,6 @@ def printf_block(
 no_value = object()
 
 
-
 def required(value: T, **kwargs: Any) -> T:
     if not value:
         raise ValueError()
@@ -115,7 +114,7 @@ def prompt_bool(
     no: str = "n",
     yes_choices: Optional[List[str]] = None,
     no_choices: Optional[List[str]] = None,
-):
+) -> Optional[bool]:
     # Backwards compatibility. Remove for version 3.0
     if yes_choices:
         yes = yes_choices[0]
@@ -181,12 +180,12 @@ class Renderer:
         self.src_path = src_path
         self.data = data
 
-    def __call__(self, fullpath: StrOrPath):
+    def __call__(self, fullpath: StrOrPath) -> str:
         relpath = str(fullpath).replace(self.src_path, "", 1).lstrip(os.path.sep)
         tmpl = self.env.get_template(relpath)
         return tmpl.render(**self.data)
 
-    def string(self, string: StrOrPath):
+    def string(self, string: StrOrPath) -> str:
         tmpl = self.env.from_string(str(string))
         return tmpl.render(**self.data)
 

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -6,13 +6,13 @@ from fnmatch import fnmatch
 from functools import reduce
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
-from mypy_extensions import Arg, KwArg
+
 import colorama  # type: ignore
 from colorama import Fore, Style
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 
-from .types import AnyByStr, CheckPathFunc, OptSeqStrOrPath, StrOrPath, T
+from .types import AnyByStr, CheckPathFunc, OptSeqStrOrPath, StrOrPath
 
 _all__: Tuple[str, ...] = (
     "STYLE_OK",
@@ -73,7 +73,7 @@ def prompt(
     question: str,
     default: Optional[Any] = no_value,
     default_show: Optional[Any] = None,
-    validator: Callable[[Arg(Any, "value"), KwArg(Any)], Any] = required,
+    validator: Callable = required,
     **kwargs: AnyByStr
 ) -> Optional[Any]:
     """
@@ -172,7 +172,9 @@ DEFAULT_ENV_OPTIONS: AnyByStr = {
 
 
 class Renderer:
-    def __init__(self, env: SandboxedEnvironment, src_path: str, data: AnyByStr):
+    def __init__(
+        self, env: SandboxedEnvironment, src_path: str, data: AnyByStr
+    ) -> None:
         self.env = env
         self.src_path = src_path
         self.data = data
@@ -201,7 +203,7 @@ def get_jinja_renderer(
     _envops.update(envops or {})
 
     paths = [_src_path] + [str(p) for p in extra_paths or []]
-    _envops.setdefault("loader", FileSystemLoader(paths))
+    _envops.setdefault("loader", FileSystemLoader(paths))  # type: ignore
 
     # We want to minimize the risk of hidden malware in the templates
     # so we use the SandboxedEnvironment instead of the regular one.

--- a/copier/types.py
+++ b/copier/types.py
@@ -9,6 +9,4 @@ AnyByStrDict = Dict[str, Any]
 OptStrOrPathSeq = Optional[Sequence[StrOrPath]]
 OptStrSeq = Optional[Sequence[str]]
 
-
-
 T = TypeVar("T")

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,9 +1,14 @@
 from pathlib import Path
-from typing import Any, Dict, Sequence, Optional, Union, Callable
+from typing import Any, Dict, Sequence, Optional, Union, TypeVar
 
-StrOrPath = Union[str, Path]
-OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
-OptSeqStr = Optional[Sequence[str]]
-AnyByStr = Dict[str, Any]
 IntOrStr = Union[int, str]
-CheckPathFunc = Callable[[StrOrPath], bool]
+StrOrPath = Union[str, Path]
+
+AnyByStrDict = Dict[str, Any]
+
+OptStrOrPathSeq = Optional[Sequence[StrOrPath]]
+OptStrSeq = Optional[Sequence[str]]
+
+
+
+T = TypeVar("T")

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from typing import Any, Dict, Sequence, Tuple, Optional, Union, Callable, List
+
+StrOrPath = Union[str, Path]
+OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
+OptSeqStr = Optional[Sequence[str]]
+AnyByStr = Dict[str, Any]
+IntOrStr = Union[int, str]
+CheckPathFunc = Callable[[StrOrPath], bool]

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Sequence, Tuple, TypeVar, Optional, Union, Callable, List
+from typing import Any, Dict, Sequence, Optional, Union, Callable
 
 StrOrPath = Union[str, Path]
 OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
@@ -7,4 +7,3 @@ OptSeqStr = Optional[Sequence[str]]
 AnyByStr = Dict[str, Any]
 IntOrStr = Union[int, str]
 CheckPathFunc = Callable[[StrOrPath], bool]
-T = TypeVar("T")

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Sequence, Tuple, Optional, Union, Callable, List
+from typing import Any, Dict, Sequence, Tuple, TypeVar, Optional, Union, Callable, List
 
 StrOrPath = Union[str, Path]
 OptSeqStrOrPath = Optional[Sequence[StrOrPath]]
@@ -7,3 +7,4 @@ OptSeqStr = Optional[Sequence[str]]
 AnyByStr = Dict[str, Any]
 IntOrStr = Union[int, str]
 CheckPathFunc = Callable[[StrOrPath], bool]
+T = TypeVar("T")

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Sequence, Optional, Union, TypeVar
+from typing import Any, Dict, Optional, Sequence, TypeVar, Union
 
 IntOrStr = Union[int, str]
 StrOrPath = Union[str, Path]

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, Union
 
 IntOrStr = Union[int, str]
 StrOrPath = Union[str, Path]
@@ -8,5 +8,7 @@ AnyByStrDict = Dict[str, Any]
 
 OptStrOrPathSeq = Optional[Sequence[StrOrPath]]
 OptStrSeq = Optional[Sequence[str]]
+
+CheckPathFunc = Callable[[StrOrPath], bool]
 
 T = TypeVar("T")

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -30,7 +30,7 @@ def load_yaml_data(src_path, quiet=False):
         if not yaml_path.exists():
             return {}
 
-    from ruamel.yaml import YAML
+    from ruamel.yaml import YAML  # type: ignore
 
     yaml = YAML(typ="safe")
 

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,14 +1,15 @@
 from pathlib import Path
+from typing import List
 
 from .tools import printf, printf_block, prompt, STYLE_WARNING
-
+from .types import AnyByStr, StrOrPath
 
 __all__ = ("load_config_data", "query_user_data")
 
 INDENT = "  "
 
 
-def load_toml_data(src_path, quiet=False):
+def load_toml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
     toml_path = Path(src_path) / "copier.toml"
     if not toml_path.exists():
         return {}
@@ -17,13 +18,13 @@ def load_toml_data(src_path, quiet=False):
 
     toml_src = toml_path.read_text()
     try:
-        return toml.loads(toml_src)
+        return dict(toml.loads(toml_src))
     except Exception as e:
-        printf_block(e, "INVALID", msg=toml_path, quiet=quiet)
+        printf_block(e, "INVALID", msg=str(toml_path), quiet=quiet)
         return {}
 
 
-def load_yaml_data(src_path, quiet=False):
+def load_yaml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
     yaml_path = Path(src_path) / "copier.yml"
     if not yaml_path.exists():
         yaml_path = Path(src_path) / "copier.yaml"
@@ -37,11 +38,13 @@ def load_yaml_data(src_path, quiet=False):
     try:
         return yaml.load(yaml_path)
     except Exception as e:
-        printf_block(e, "INVALID", msg=yaml_path, quiet=quiet)
+        printf_block(e, "INVALID", msg=str(yaml_path), quiet=quiet)
         return {}
 
 
-def load_json_data(src_path, quiet=False, _warning=True):
+def load_json_data(
+    src_path: StrOrPath, quiet: bool = False, _warning: bool = True
+) -> AnyByStr:
     json_path = Path(src_path) / "copier.json"
     if not json_path.exists():
         return load_old_json_data(src_path, quiet=quiet, _warning=_warning)
@@ -52,11 +55,13 @@ def load_json_data(src_path, quiet=False, _warning=True):
     try:
         return json.loads(json_src)
     except ValueError as e:
-        printf_block(e, "INVALID", msg=json_path, quiet=quiet)
+        printf_block(e, "INVALID", msg=str(json_path), quiet=quiet)
         return {}
 
 
-def load_old_json_data(src_path, quiet=False, _warning=True):
+def load_old_json_data(
+    src_path: StrOrPath, quiet: bool = False, _warning: bool = True
+) -> AnyByStr:
     # TODO: Remove on version 3.0
     json_path = Path(src_path) / "voodoo.json"
     if not json_path.exists():
@@ -78,11 +83,13 @@ def load_old_json_data(src_path, quiet=False, _warning=True):
     try:
         return json.loads(json_src)
     except ValueError as e:
-        printf_block(e, "INVALID", msg=json_path, quiet=quiet)
+        printf_block(e, "INVALID", msg=str(json_path), quiet=quiet)
         return {}
 
 
-def load_config_data(src_path, quiet=False, _warning=True):
+def load_config_data(
+    src_path: StrOrPath, quiet: bool = False, _warning: bool = True
+) -> AnyByStr:
     """Try to load the content from a `copier.yml`, a `copier.toml`, a `copier.json`,
     or the deprecated `voodoo.json`, in that order.
     """
@@ -95,7 +102,7 @@ def load_config_data(src_path, quiet=False, _warning=True):
     return data
 
 
-def query_user_data(default_user_data):  # pragma:no cover
+def query_user_data(default_user_data: AnyByStr) -> AnyByStr:  # pragma:no cover
     """Query to user about the data of the config file.
     """
     if not default_user_data:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
 from .tools import printf, printf_block, prompt, STYLE_WARNING
-from .types import AnyByStr, StrOrPath
+from .types import AnyByStrDict, StrOrPath
 
 __all__ = ("load_config_data", "query_user_data")
 
 INDENT = "  "
 
 
-def load_toml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
+def load_toml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStrDict:
     toml_path = Path(src_path) / "copier.toml"
     if not toml_path.exists():
         return {}
@@ -23,7 +23,7 @@ def load_toml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
         return {}
 
 
-def load_yaml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
+def load_yaml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStrDict:
     yaml_path = Path(src_path) / "copier.yml"
     if not yaml_path.exists():
         yaml_path = Path(src_path) / "copier.yaml"
@@ -43,7 +43,7 @@ def load_yaml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
 
 def load_json_data(
     src_path: StrOrPath, quiet: bool = False, _warning: bool = True
-) -> AnyByStr:
+) -> AnyByStrDict:
     json_path = Path(src_path) / "copier.json"
     if not json_path.exists():
         return load_old_json_data(src_path, quiet=quiet, _warning=_warning)
@@ -60,7 +60,7 @@ def load_json_data(
 
 def load_old_json_data(
     src_path: StrOrPath, quiet: bool = False, _warning: bool = True
-) -> AnyByStr:
+) -> AnyByStrDict:
     # TODO: Remove on version 3.0
     json_path = Path(src_path) / "voodoo.json"
     if not json_path.exists():
@@ -88,7 +88,7 @@ def load_old_json_data(
 
 def load_config_data(
     src_path: StrOrPath, quiet: bool = False, _warning: bool = True
-) -> AnyByStr:
+) -> AnyByStrDict:
     """Try to load the content from a `copier.yml`, a `copier.toml`, a `copier.json`,
     or the deprecated `voodoo.json`, in that order.
     """
@@ -101,7 +101,7 @@ def load_config_data(
     return data
 
 
-def query_user_data(default_user_data: AnyByStr) -> AnyByStr:  # pragma:no cover
+def query_user_data(default_user_data: AnyByStrDict) -> AnyByStrDict:  # pragma:no cover
     """Query to user about the data of the config file.
     """
     if not default_user_data:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .tools import printf, printf_block, prompt, STYLE_WARNING
+from .tools import STYLE_WARNING, printf, printf_block, prompt
 from .types import AnyByStrDict, StrOrPath
 
 __all__ = ("load_config_data", "query_user_data")

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -13,7 +13,7 @@ def load_toml_data(src_path: StrOrPath, quiet: bool = False) -> AnyByStr:
     if not toml_path.exists():
         return {}
 
-    import toml
+    import toml  # type: ignore
 
     toml_src = toml_path.read_text()
     try:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 from .tools import printf, printf_block, prompt, STYLE_WARNING
 from .types import AnyByStr, StrOrPath

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -3,7 +3,9 @@ import re
 import tempfile
 import shutil
 import subprocess
+from typing import Optional
 
+from .types import StrOrPath
 
 __all__ = ("get_repo", "clone")
 
@@ -14,7 +16,7 @@ RE_GITHUB = re.compile(r"^gh:/?")
 RE_GITLAB = re.compile(r"^gl:/?")
 
 
-def get_repo(url):
+def get_repo(url: StrOrPath) -> Optional[str]:
     url = str(url)  # In case we have got a `pathlib.Path`
     if not (url.endswith(GIT_POSTFIX) or url.startswith(GIT_PREFIX)):
         return None
@@ -27,7 +29,7 @@ def get_repo(url):
     return url
 
 
-def clone(url):
+def clone(url: str) -> str:
     location = tempfile.mkdtemp()
     shutil.rmtree(location)  # Path must not exists
     subprocess.check_call(["git", "clone", url, location])

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -1,8 +1,8 @@
 import os
 import re
-import tempfile
 import shutil
 import subprocess
+import tempfile
 from typing import Optional
 
 from .types import StrOrPath

--- a/copier/version.py
+++ b/copier/version.py
@@ -1,7 +1,5 @@
 import pkg_resources
 
-from typing import Optional
-
 try:
     __version__: str = pkg_resources.require("copier")[0].version
 except Exception:  # pragma:no cover

--- a/copier/version.py
+++ b/copier/version.py
@@ -1,8 +1,9 @@
 import pkg_resources
 
+from typing import Optional
 
 try:
-    __version__ = pkg_resources.require("copier")[0].version
+    __version__: str = pkg_resources.require("copier")[0].version
 except Exception:  # pragma:no cover
     # Run pytest without needing to install the library
-    __version__ = None
+    __version__ = None  # type: ignore

--- a/mm.py
+++ b/mm.py
@@ -19,8 +19,7 @@ data = {
     "copyright": "2011",
     "repo_name": "jpscaletti/copier",
     "home_url": "",
-    "project_urls": {
-    },
+    "project_urls": {},
     "development_status": "5 - Production/Stable",
     "minimal_python": 3.5,
     "install_requires": [
@@ -29,21 +28,10 @@ data = {
         "toml ~= 0.10",
         "ruamel.yaml ~= 0.15",
     ],
-    "testing_requires": [
-        "pytest",
-        "pytest-mock",
-    ],
-    "development_requires": [
-        "pytest-cov",
-        "pytest-flake8",
-        "flake8",
-        "ipdb",
-        "tox",
-    ],
+    "testing_requires": ["pytest", "pytest-mock"],
+    "development_requires": ["pytest-cov", "pytest-flake8", "flake8", "ipdb", "tox"],
     "entry_points": "copier = copier.cli:run",
-
     "coverage_omit": [],
-
     "has_docs": False,
     "google_analytics": "UA-XXXXXXXX-X",
     "docs_nav": [],
@@ -56,7 +44,6 @@ exclude = [
     ".git/*",
     ".venv",
     ".venv/*",
-
     "docs",
     "docs/*",
 ]
@@ -84,7 +71,7 @@ def do_the_thing():
         data=data,
         exclude=exclude,
         force=True,
-        cleanup_on_error=False
+        cleanup_on_error=False,
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ universal = 1
 [options]
 include_package_data = true
 packages = find:
-python_requires = >=3.5,<4.0
+python_requires = >=3.6,<4.0
 install_requires =
     jinja2 ~= 2.10
     colorama ~= 0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,11 +38,13 @@ exclude =
 testing =
     pytest
     pytest-mock
+    pytest-mypy
 
 dev =
     # Testing & Validation
     pytest
     pytest-mock
+    pytest-mypy
     pytest-cov
     pytest-flake8
     flake8

--- a/tests/demo/pyproject.toml.tmpl
+++ b/tests/demo/pyproject.toml.tmpl
@@ -13,4 +13,4 @@ homepage = "https://github.com/jpscaletti/copier"
 
 # Requirements
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"

--- a/tests/pyproject.toml.ref
+++ b/tests/pyproject.toml.ref
@@ -13,4 +13,4 @@ homepage = "https://github.com/jpscaletti/copier"
 
 # Requirements
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -4,13 +4,7 @@ import pytest
 
 from .. import copier
 
-from .helpers import (
-    assert_file,
-    render,
-    PROJECT_TEMPLATE,
-    DATA,
-    filecmp,
-)
+from .helpers import assert_file, render, PROJECT_TEMPLATE, DATA, filecmp
 
 
 def test_project_not_found(dst):
@@ -68,10 +62,7 @@ def test_exclude_file(dst):
 def test_skip_if_exists(dst):
     copier.copy("tests/demo_skip_dst", dst)
     copier.copy(
-        "tests/demo_skip_src",
-        dst,
-        skip_if_exists=["b.txt", "meh/c.txt"],
-        force=True
+        "tests/demo_skip_src", dst, skip_if_exists=["b.txt", "meh/c.txt"], force=True
     )
 
     assert (dst / "a.txt").read_text() == "OVERWRITTEN"
@@ -86,7 +77,7 @@ def test_skip_if_exists_rendered_patterns(dst):
         dst,
         data={"name": "meh"},
         skip_if_exists=["[[ name ]]/c.txt"],
-        force=True
+        force=True,
     )
     assert (dst / "a.txt").read_text() == "OVERWRITTEN"
     assert (dst / "b.txt").read_text() == "OVERWRITTEN"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -23,13 +23,14 @@ def test_config_data_is_loaded_from_file():
 
 
 @pytest.mark.parametrize(
-    "template", [
+    "template",
+    [
         "tests/demo_toml",
         "tests/demo_yaml",
         "tests/demo_yml",
         "tests/demo_json",
         "tests/demo_json_old",
-    ]
+    ],
 )
 def test_read_data(dst, template):
     copier.copy(template, dst, force=True)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -125,7 +125,7 @@ def test_prompt_bool_no_default(stdin, capsys):
     stdin.append("\ny\n")
     prompt_bool(question, default=None)
     stdout, _ = capsys.readouterr()
-    assert '{} [y/n] '.format(question) in stdout
+    assert "{} [y/n] ".format(question) in stdout
     assert 'Please answer "y" or "n"' in stdout
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
@jpscaletti You said you wanted to "try this idea". So here it is:

This **PR** introduced a complete type annotation of the entire `copier` module.
*MyPy and all tests run green in my local setup.*

The general Pros and Cons of type annotations apply here as well.

#### Cons - Why not to merge:
The code becomes bulkier even bloated at some places. Especially as we employ many functions with long signatures, those signatures will definitely turn into multi-line monstrosities. At other places, the amount of code grew due to introducing new variables or type conversions.

#### Pros - Why merge:
It enforces stringency and makes refactoring a joy. Working on another **PR**, that for #49, the significant refactoring involved killed half the tests in my first attempt. Now my second attempt is being guided by the type annotations. It makes it easier as I have a clear picture and immediate feedback on what newly introduced functions should return. You might say "everything clicks in place" as lego pieces do.


#### TODO:
- [x]  ~~Are type aliases named idiomatically?~~ _No, idioms found._
- [x]  Check whether types could be made more stringent.
    - [x] Is `Optional` overused?
- [x]  Remove `mypy_extensions` dependency.
- [x]  Make Travis' tests green.
- [x]  Add type checking to the test routine.
- [x] Drop Python 3.5 support.


Closes: #42