### PR TITLE
Enable tests for Python 3.8 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
+dist: bionic
 language: python
+python:
+  - '3.6'
+  - '3.7'
+  - '3.8-dev'
+  - 'nightly'
 
 matrix:
-  include:
-    - python: 3.6
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  allow_failures:
+    - python: 'nightly'
 
 before_install:
   - pip install -U pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 
 [bdist_wheel]


### PR DESCRIPTION
Hello,

Python 3.8 is [almost there](https://pythoninsider.blogspot.com/2019/08/python-380b4-is-now-available-for.html), so it would be nice to see tests for it on CI.

These changes also:
 - add more precise classifiers

Best regards!